### PR TITLE
Fix implementation for addorder

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddOrderCommand.java
@@ -10,7 +10,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.order.Date;
+import seedu.address.model.order.Order;
 import seedu.address.model.person.Person;
 
 /**
@@ -30,20 +30,17 @@ public class AddOrderCommand extends Command {
             + "d/ 2024-01-01 r/ 100 chicken wings.";
 
     private final Index index;
-    private final Date arrivalDate;
-    private final String remark;
+    private final Order order;
 
     /**
      * Creates an AddOrderCommand to add the specified {@code Person}
      */
-    public AddOrderCommand(Index index, Date arrivalDate, String remark) {
+    public AddOrderCommand(Index index, Order order) {
         requireNonNull(index);
-        requireNonNull(arrivalDate);
-        requireNonNull(remark);
+        requireNonNull(order);
 
         this.index = index;
-        this.arrivalDate = arrivalDate;
-        this.remark = remark;
+        this.order = order;
     }
 
     @Override
@@ -56,8 +53,7 @@ public class AddOrderCommand extends Command {
 
         Person person = lastShownList.get(index.getZeroBased());
 
-        // TODO
-        person.addOrder(this.arrivalDate, this.remark);
+        person.addOrder(this.order);
 
         model.setPerson(person, person);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
@@ -76,17 +72,14 @@ public class AddOrderCommand extends Command {
         }
 
         AddOrderCommand otherAddOrderCommand = (AddOrderCommand) other;
-        return index.equals(otherAddOrderCommand.index)
-                && arrivalDate.equals(otherAddOrderCommand.arrivalDate)
-                && remark.equals(otherAddOrderCommand.remark);
+        return order.equals(otherAddOrderCommand.order) && index.equals(otherAddOrderCommand.index);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .add("index", index)
-                .add("arrivalDate", arrivalDate)
-                .add("remark", remark)
+                .add("order", order)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddOrderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddOrderCommandParser.java
@@ -9,6 +9,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddOrderCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.order.Date;
+import seedu.address.model.order.Order;
 
 /**
  * Parses input arguments and creates a new AddOrderCommand object
@@ -40,9 +41,10 @@ public class AddOrderCommandParser implements Parser<AddOrderCommand> {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_DATE, PREFIX_REMARK);
 
         Date arrivalDate = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
-
         String remark = argMultimap.getValue(PREFIX_REMARK).get();
 
-        return new AddOrderCommand(index, arrivalDate, remark);
+        Order order = new Order(arrivalDate, remark);
+
+        return new AddOrderCommand(index, order);
     }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -9,7 +9,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.model.order.Date;
 import seedu.address.model.order.Order;
 import seedu.address.model.tag.Tag;
 
@@ -94,11 +93,9 @@ public class Person {
 
     /**
      * Returns an order list
-     * @param arrivalDate the expected date of the order received
-     * @param remark the remark of the order
+     * @param order the order to be added
      */
-    public void addOrder(Date arrivalDate, String remark) {
-        Order order = new Order(arrivalDate, remark);
+    public void addOrder(Order order) {
         orders.add(order);
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddOrderCommandTest.java
@@ -26,26 +26,24 @@ import seedu.address.testutil.PersonBuilder;
 public class AddOrderCommandTest {
     private static final Date DATE_STUB = new Date("2020-01-01");
     private static final String REMARK_STUB = "100 chicken wings";
-    private static final ArrayList<Order> ORDERS_STUB = new ArrayList<>(
-            List.of(new Order(new Date("2020-01-01"), "100 chicken wings")));
+    private static final Order ORDER_STUB = new Order(DATE_STUB, REMARK_STUB);
+    private static final ArrayList<Order> ORDERS_STUB = new ArrayList<>(List.of(ORDER_STUB));
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void constructor_nullOrder_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new AddOrderCommand(null, DATE_STUB, REMARK_STUB));
+        assertThrows(NullPointerException.class, () -> new AddOrderCommand(null, ORDER_STUB));
         assertThrows(NullPointerException.class, () -> new AddOrderCommand(Index.fromOneBased(1),
-                null, REMARK_STUB));
-        assertThrows(NullPointerException.class, () -> new AddOrderCommand(Index.fromOneBased(1),
-                DATE_STUB, null));
-        assertThrows(NullPointerException.class, () -> new AddOrderCommand(null, null, null));
+                null));
+        assertThrows(NullPointerException.class, () -> new AddOrderCommand(null, null));
     }
 
     @Test
     public void execute_addOrder_success() {
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PersonBuilder(firstPerson).withOrders(ORDERS_STUB).build();
-        AddOrderCommand addOrderCommand = new AddOrderCommand(INDEX_FIRST_PERSON, DATE_STUB, REMARK_STUB);
+        AddOrderCommand addOrderCommand = new AddOrderCommand(INDEX_FIRST_PERSON, ORDER_STUB);
 
         String expectedMessage = String.format(AddOrderCommand.MESSAGE_SUCCESS, Messages.format(editedPerson));
 
@@ -58,20 +56,20 @@ public class AddOrderCommandTest {
     @Test
     public void execute_invalidIndex_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        AddOrderCommand addOrderCommand = new AddOrderCommand(outOfBoundIndex, DATE_STUB, REMARK_STUB);
+        AddOrderCommand addOrderCommand = new AddOrderCommand(outOfBoundIndex, ORDER_STUB);
         assertThrows(CommandException.class, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, () ->
                 addOrderCommand.execute(model));
     }
 
     @Test
     public void equals() {
-        AddOrderCommand addOrderCommand = new AddOrderCommand(INDEX_FIRST_PERSON, DATE_STUB, REMARK_STUB);
+        AddOrderCommand addOrderCommand = new AddOrderCommand(INDEX_FIRST_PERSON, ORDER_STUB);
 
         // same object -> returns true
         assert (addOrderCommand.equals(addOrderCommand));
 
         // same values -> returns true
-        AddOrderCommand addOrderCommandCopy = new AddOrderCommand(INDEX_FIRST_PERSON, DATE_STUB, REMARK_STUB);
+        AddOrderCommand addOrderCommandCopy = new AddOrderCommand(INDEX_FIRST_PERSON, ORDER_STUB);
         assert (addOrderCommand.equals(addOrderCommandCopy));
 
         // different types -> returns false
@@ -81,23 +79,25 @@ public class AddOrderCommandTest {
         assert (!addOrderCommand.equals(null));
 
         // different index -> returns false
-        AddOrderCommand differentOrderCommand = new AddOrderCommand(Index.fromOneBased(2), DATE_STUB, REMARK_STUB);
+        AddOrderCommand differentOrderCommand = new AddOrderCommand(Index.fromOneBased(2), ORDER_STUB);
         assert (!addOrderCommand.equals(differentOrderCommand));
 
         // different date -> returns false
-        differentOrderCommand = new AddOrderCommand(INDEX_FIRST_PERSON, new Date("2020-01-02"), REMARK_STUB);
+        Order orderWithDifferentDate = new Order(new Date("2020-01-02"), REMARK_STUB);
+        differentOrderCommand = new AddOrderCommand(INDEX_FIRST_PERSON, orderWithDifferentDate);
         assert (!addOrderCommand.equals(differentOrderCommand));
 
         // different remark -> returns false
-        differentOrderCommand = new AddOrderCommand(INDEX_FIRST_PERSON, DATE_STUB, "200 chicken wings");
+        Order orderWithDifferentRemark = new Order(DATE_STUB, "200 chicken wings");
+        differentOrderCommand = new AddOrderCommand(INDEX_FIRST_PERSON, orderWithDifferentRemark);
         assert (!addOrderCommand.equals(differentOrderCommand));
     }
 
     @Test
     public void toStringMethod() {
-        AddOrderCommand addOrderCommand = new AddOrderCommand(INDEX_FIRST_PERSON, DATE_STUB, REMARK_STUB);
+        AddOrderCommand addOrderCommand = new AddOrderCommand(INDEX_FIRST_PERSON, ORDER_STUB);
         String expected = AddOrderCommand.class.getCanonicalName() + "{index=" + INDEX_FIRST_PERSON
-                + ", arrivalDate=" + DATE_STUB + ", remark=" + REMARK_STUB + "}";
+                + ", order=" + ORDER_STUB + "}";
         assertEquals(expected, addOrderCommand.toString());
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddOrderCommandTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -73,24 +74,24 @@ public class AddOrderCommandTest {
         assert (addOrderCommand.equals(addOrderCommandCopy));
 
         // different types -> returns false
-        assert (!addOrderCommand.equals(1));
+        assertFalse(addOrderCommand.equals(1));
 
         // null -> returns false
-        assert (!addOrderCommand.equals(null));
+        assertFalse(addOrderCommand.equals(null));
 
         // different index -> returns false
         AddOrderCommand differentOrderCommand = new AddOrderCommand(Index.fromOneBased(2), ORDER_STUB);
-        assert (!addOrderCommand.equals(differentOrderCommand));
+        assertFalse(addOrderCommand.equals(differentOrderCommand));
 
         // different date -> returns false
         Order orderWithDifferentDate = new Order(new Date("2020-01-02"), REMARK_STUB);
         differentOrderCommand = new AddOrderCommand(INDEX_FIRST_PERSON, orderWithDifferentDate);
-        assert (!addOrderCommand.equals(differentOrderCommand));
+        assertFalse(addOrderCommand.equals(differentOrderCommand));
 
         // different remark -> returns false
         Order orderWithDifferentRemark = new Order(DATE_STUB, "200 chicken wings");
         differentOrderCommand = new AddOrderCommand(INDEX_FIRST_PERSON, orderWithDifferentRemark);
-        assert (!addOrderCommand.equals(differentOrderCommand));
+        assertFalse(addOrderCommand.equals(differentOrderCommand));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddOrderCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddOrderCommandParserTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddOrderCommand;
 import seedu.address.model.order.Date;
+import seedu.address.model.order.Order;
 
 public class AddOrderCommandParserTest {
     private static final String NON_EMPTY_DATE = "2020-01-01";
@@ -26,8 +27,9 @@ public class AddOrderCommandParserTest {
         String userInput = INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_DATE + NON_EMPTY_DATE + " "
                 + PREFIX_REMARK + NON_EMPTY_REMARK;
 
-        AddOrderCommand expectedCommand = new AddOrderCommand(INDEX_FIRST_PERSON, new Date(NON_EMPTY_DATE),
-                NON_EMPTY_REMARK);
+        Order order = new Order(new Date(NON_EMPTY_DATE), NON_EMPTY_REMARK);
+
+        AddOrderCommand expectedCommand = new AddOrderCommand(INDEX_FIRST_PERSON, order);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -27,6 +27,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.order.Date;
+import seedu.address.model.order.Order;
 import seedu.address.model.person.NameAndTagContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -68,9 +69,10 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_addOrder() throws Exception {
+        Order order = new Order(new Date("2020-01-01"), "100 chicken wings");
         AddOrderCommand command = (AddOrderCommand) parser.parseCommand(AddOrderCommand.COMMAND_WORD + " "
                         + INDEX_FIRST_PERSON.getOneBased() + " d/2020-01-01 r/100 chicken wings");
-        assertEquals(new AddOrderCommand(INDEX_FIRST_PERSON, new Date("2020-01-01"), "100 chicken wings"), command);
+        assertEquals(new AddOrderCommand(INDEX_FIRST_PERSON, order), command);
     }
 
     @Test


### PR DESCRIPTION
Previous implementation:
- `Order` is only created at `Person` class.

New implementation:
- `Order` is now created at `AddOrderCommandParser` class.

Rationale:
- The add command creates the `Person` class at `AddCommandParser`, so I thought it would be better if the addorder command follows this convention as well