### PR TITLE
Delete favourites

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -105,7 +105,6 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [c/COMPANY] [t/TAG]
 * Edits the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
-* When editing tags, existing tags other than the Favourite tag of the person will be removed i.e adding of tags is not cumulative.
 * You can remove all the person’s tags by typing `t/` without
     specifying any tags after it.
 
@@ -114,7 +113,7 @@ Examples:
 *  `edit 2 n/Betsy Crower t/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
 
 
-### Add Contacts as Favourites `addfav`
+### Add contacts as favourites `addfav`
 
 - Adds the contacts specified by index as favourites
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -118,7 +118,11 @@ Examples:
 - Adds the contacts specified by index as favourites
 
 Format: `addfav [i/INDICES]`
-- Adds the contacts at the specified `INDICES` as favourites. The indices refer to comma-separated index numbers (i.e. index, index, index) shown in the displayed person list. Each index **must be a positive integer** 1,2,3, ...
+- Adds the contacts at the specified `INDICES` as favourites. The indices refer to comma-separated index numbers (i.e. index, index, index) shown in the displayed person list. Each index **must be a positive integer** 1,2,3, ... 
+<box type="tip" seamless>
+
+**Note:** Indices corresponding to existing favourite contacts are deemed as invalid indices for `addfav`
+</box>
 
 Examples:
 - `addfav i/ 1` Sets the contact at index `1` as favourite
@@ -129,6 +133,28 @@ Examples:
 - `addfav i/` returns an error message as the 'INDICES' field cannot be empty
 - `addfav` returns an error message as it must be accompanied by the 'INDICES' field
 - `addfav 1 i/ 2, 5` returns an error message as there should not be prefixes before the 'INDICES' field
+
+### Remove contacts from favourites `removefav`
+
+- Remove the contacts specified by index as favourites
+
+Format: `removefav [i/INDICES]`
+- Removes the contacts at the specified `INDICES` from favourites. The indices refer to comma-separated index numbers (i.e. index, index, index) shown in the displayed person list. Each index **must be a positive integer** 1,2,3, ... 
+
+<box type="tip" seamless>
+
+**Note:** Indices corresponding to non-favourite contacts are deemed as invalid indices for `removefav`
+</box>
+
+Examples:
+- `removefav i/ 1` Removes the contact at index `1` from favourites
+- `removefav i/ 1, 1, 1` Removes the contact at index `1` as favourite once
+- `removefav i/ 1, 2, 5` Removes the contacts at the indices `1, 2, 5` as favourites
+- `removefav i/ -10, 0, -100`, `addfav i/ abc` and `addfav i/////` return an error message as the 'INDICES' field must consist of comma-separated positive integers
+- `removefav i/ 10, 1` returns an error message as the 'INDICES' field must consist of valid index values which are positive integers from 1 to the total number of contacts in the address book
+- `removefav i/` returns an error message as the 'INDICES' field cannot be empty
+- `removefav` returns an error message as it must be accompanied by the 'INDICES' field
+- `removefav 1 i/ 2, 5` returns an error message as there should not be prefixes before the 'INDICES' field
 
 ### Search Contact `find`
 

--- a/src/main/java/seedu/address/logic/commands/AddFavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddFavouriteCommand.java
@@ -68,8 +68,8 @@ public class AddFavouriteCommand extends Command {
             return false;
         }
 
-        AddFavouriteCommand otherAddOrderCommand = (AddFavouriteCommand) other;
-        return this.indices.equals(otherAddOrderCommand.indices);
+        AddFavouriteCommand otherAddFavouriteCommand = (AddFavouriteCommand) other;
+        return this.indices.equals(otherAddFavouriteCommand.indices);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddFavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddFavouriteCommand.java
@@ -25,7 +25,8 @@ public class AddFavouriteCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds contacts identified by index number "
             + "as favourites.\n"
-            + "Parameters: i/ [INDICES] (must be positive integers separated by commas)\n"
+            + "Parameters: i/ [INDICES] (must be positive integers separated by "
+            + "commas that correspond to non-favourite contacts)\n"
             + "Example: " + COMMAND_WORD + " "
             + "i/ 1,2,5";
 
@@ -46,6 +47,11 @@ public class AddFavouriteCommand extends Command {
         boolean anyGreaterThanSize = this.indices.stream().anyMatch(index -> index.getZeroBased() >= people.size());
         if (anyGreaterThanSize) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+        boolean anyFavourite = this.indices.stream().anyMatch(index ->
+                people.get(index.getZeroBased()).getFavourite());
+        if (anyFavourite) {
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
         }
         for (Index index : this.indices) {
             Person person = people.get(index.getZeroBased());

--- a/src/main/java/seedu/address/logic/commands/RemoveFavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveFavouriteCommand.java
@@ -15,7 +15,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
 /**
- * Adds the indicated contacts in the address book as favourites
+ * Removes the indicated contacts in the address book from favourites
  */
 public class RemoveFavouriteCommand extends Command {
     public static final String COMMAND_WORD = "removefav";
@@ -51,7 +51,7 @@ public class RemoveFavouriteCommand extends Command {
         for (Index index : this.indices) {
             Person person = people.get(index.getZeroBased());
             if (!person.getFavourite()) {
-                throw new CommandException(Messages.MESSAGE_INVALID_COMMAND_FORMAT);
+                throw new CommandException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
             }
             modifiedContacts.add(person.getName().fullName);
             person.removeFavourite();

--- a/src/main/java/seedu/address/logic/commands/RemoveFavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveFavouriteCommand.java
@@ -50,7 +50,8 @@ public class RemoveFavouriteCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
-        boolean anyNotFavourite = this.indices.stream().anyMatch(index -> !people.get(index.getZeroBased()).getFavourite());
+        boolean anyNotFavourite = this.indices.stream().anyMatch(index ->
+                !people.get(index.getZeroBased()).getFavourite());
         if (anyNotFavourite) {
             throw new CommandException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/commands/RemoveFavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveFavouriteCommand.java
@@ -44,15 +44,19 @@ public class RemoveFavouriteCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         List<Person> people = model.getFilteredPersonList();
         List<String> modifiedContacts = new ArrayList<>();
+
         boolean anyGreaterThanSize = this.indices.stream().anyMatch(index -> index.getZeroBased() >= people.size());
         if (anyGreaterThanSize) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
+
+        boolean anyNotFavourite = this.indices.stream().anyMatch(index -> !people.get(index.getZeroBased()).getFavourite());
+        if (anyNotFavourite) {
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        }
+
         for (Index index : this.indices) {
             Person person = people.get(index.getZeroBased());
-            if (!person.getFavourite()) {
-                throw new CommandException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
-            }
             modifiedContacts.add(person.getName().fullName);
             person.removeFavourite();
             model.setPerson(person, person);

--- a/src/main/java/seedu/address/logic/commands/RemoveFavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveFavouriteCommand.java
@@ -1,0 +1,87 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Adds the indicated contacts in the address book as favourites
+ */
+public class RemoveFavouriteCommand extends Command {
+    public static final String COMMAND_WORD = "removefav";
+
+    public static final String MESSAGE_SUCCESS = "The following contacts have been removed from favourites: %s";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Removes contacts identified by index number "
+            + "as favourites.\n"
+            + "Parameters: i/ [INDICES] (must be positive integers separated by "
+            + "commas that correspond to existing favourite contacts)\n"
+            + "Example: " + COMMAND_WORD + " "
+            + "i/ 1,2,5";
+
+    private final Set<Index> indices;
+
+    /**
+     * Creates an AddFavouriteCommand to mark the specified group of {@code Person} as favourites
+     */
+    public RemoveFavouriteCommand(Set<Index> indices) {
+        requireNonNull(indices);
+        this.indices = indices;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        List<Person> people = model.getFilteredPersonList();
+        List<String> modifiedContacts = new ArrayList<>();
+        boolean anyGreaterThanSize = this.indices.stream().anyMatch(index -> index.getZeroBased() >= people.size());
+        if (anyGreaterThanSize) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+        for (Index index : this.indices) {
+            Person person = people.get(index.getZeroBased());
+            if (!person.getFavourite()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_COMMAND_FORMAT);
+            }
+            modifiedContacts.add(person.getName().fullName);
+            person.removeFavourite();
+            model.setPerson(person, person);
+        }
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, modifiedContacts));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof RemoveFavouriteCommand)) {
+            return false;
+        }
+
+        RemoveFavouriteCommand otherRemoveFavouriteCommand = (RemoveFavouriteCommand) other;
+        return this.indices.equals(otherRemoveFavouriteCommand.indices);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        this.indices.forEach(sb::append);
+        return new ToStringBuilder(this)
+                .add("indices", sb.toString())
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddFavouriteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddFavouriteCommandParser.java
@@ -36,9 +36,7 @@ public class AddFavouriteCommandParser implements Parser<AddFavouriteCommand> {
         if (listIndices.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddFavouriteCommand.MESSAGE_USAGE));
         }
-        // The regex ,(?=\\d|\\s) uses the lookahead operator to only split by commas that are followed by
-        // numbers or whitespace to handle invalid indices like ,,,,, and 1,,,,,,
-        String[] indexKeywordsArray = listIndices.get(0).split(",(?=\\d|\\s)");
+        String[] indexKeywordsArray = ParserUtil.parseCsv(listIndices.get(0));
         List<Index> indices = new ArrayList<>();
         for (String index : indexKeywordsArray) {
             try {

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -20,6 +20,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListOrderCommand;
+import seedu.address.logic.commands.RemoveFavouriteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -73,6 +74,9 @@ public class AddressBookParser {
 
         case AddFavouriteCommand.COMMAND_WORD:
             return new AddFavouriteCommandParser().parse(arguments);
+
+        case RemoveFavouriteCommand.COMMAND_WORD:
+            return new RemoveFavouriteCommandParser().parse(arguments);
 
         case AddOrderCommand.COMMAND_WORD:
             return new AddOrderCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -152,4 +152,14 @@ public class ParserUtil {
         }
         return tagSet;
     }
+
+    /**
+     * Parses {@code String csv} into a {@code String[]}
+     */
+    public static String[] parseCsv(String csv) {
+        requireNonNull(csv);
+        // The regex ,(?=\\d|\\s) uses the lookahead operator to only split by commas that are followed by
+        // numbers or whitespace to handle invalid indices like ,,,,, and 1,,,,,,
+        return csv.split(",(?=\\d|\\s)");
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/RemoveFavouriteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemoveFavouriteCommandParser.java
@@ -1,0 +1,54 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDICES;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.RemoveFavouriteCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new AddFavouriteCommand object
+ */
+public class RemoveFavouriteCommandParser implements Parser<RemoveFavouriteCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddFavouriteCommand
+     * and returns an AddFavouriteCommand object for execution
+     * @throws ParseException if the user input does not conform to the expected format
+     */
+    public RemoveFavouriteCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_INDICES);
+
+        // Ensure no preamble exists.
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveFavouriteCommand.MESSAGE_USAGE));
+        }
+        argMultimap.verifyNonEmptyKeywordValues(PREFIX_INDICES);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_INDICES);
+        List<String> listIndices = argMultimap.getAllValues(PREFIX_INDICES);
+        if (listIndices.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveFavouriteCommand.MESSAGE_USAGE));
+        }
+        // The regex ,(?=\\d|\\s) uses the lookahead operator to only split by commas that are followed by
+        // numbers or whitespace to handle invalid indices like ,,,,, and 1,,,,,,
+        String[] indexKeywordsArray = listIndices.get(0).split(",(?=\\d|\\s)");
+        List<Index> indices = new ArrayList<>();
+        for (String index : indexKeywordsArray) {
+            try {
+                Index currentIndex = ParserUtil.parseIndex(index);
+                indices.add(currentIndex);
+            } catch (ParseException pe) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        RemoveFavouriteCommand.MESSAGE_USAGE), pe);
+            }
+        }
+        return new RemoveFavouriteCommand(new HashSet<>(indices));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/RemoveFavouriteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemoveFavouriteCommandParser.java
@@ -13,13 +13,13 @@ import seedu.address.logic.commands.RemoveFavouriteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a new AddFavouriteCommand object
+ * Parses input arguments and creates a new RemoveFavouriteCommand object
  */
 public class RemoveFavouriteCommandParser implements Parser<RemoveFavouriteCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the AddFavouriteCommand
-     * and returns an AddFavouriteCommand object for execution
+     * Parses the given {@code String} of arguments in the context of the RemoveFavouriteCommand
+     * and returns an RemoveFavouriteCommand object for execution
      * @throws ParseException if the user input does not conform to the expected format
      */
     public RemoveFavouriteCommand parse(String args) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/RemoveFavouriteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemoveFavouriteCommandParser.java
@@ -38,9 +38,7 @@ public class RemoveFavouriteCommandParser implements Parser<RemoveFavouriteComma
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     RemoveFavouriteCommand.MESSAGE_USAGE));
         }
-        // The regex ,(?=\\d|\\s) uses the lookahead operator to only split by commas that are followed by
-        // numbers or whitespace to handle invalid indices like ,,,,, and 1,,,,,,
-        String[] indexKeywordsArray = listIndices.get(0).split(",(?=\\d|\\s)");
+        String[] indexKeywordsArray = ParserUtil.parseCsv(listIndices.get(0));
         List<Index> indices = new ArrayList<>();
         for (String index : indexKeywordsArray) {
             try {

--- a/src/main/java/seedu/address/logic/parser/RemoveFavouriteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemoveFavouriteCommandParser.java
@@ -28,13 +28,15 @@ public class RemoveFavouriteCommandParser implements Parser<RemoveFavouriteComma
 
         // Ensure no preamble exists.
         if (!argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveFavouriteCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    RemoveFavouriteCommand.MESSAGE_USAGE));
         }
         argMultimap.verifyNonEmptyKeywordValues(PREFIX_INDICES);
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_INDICES);
         List<String> listIndices = argMultimap.getAllValues(PREFIX_INDICES);
         if (listIndices.isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveFavouriteCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    RemoveFavouriteCommand.MESSAGE_USAGE));
         }
         // The regex ,(?=\\d|\\s) uses the lookahead operator to only split by commas that are followed by
         // numbers or whitespace to handle invalid indices like ,,,,, and 1,,,,,,

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -105,6 +105,12 @@ public class Person {
     public void addFavourite() {
         this.isFavourite = true;
     }
+    /**
+     * Removes the person specified by the contact from favourites
+     */
+    public void removeFavourite() {
+        this.isFavourite = false;
+    }
 
     public boolean getFavourite() {
         return this.isFavourite;

--- a/src/test/java/seedu/address/logic/commands/AddFavouriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddFavouriteCommandTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -25,6 +26,8 @@ import seedu.address.testutil.PersonBuilder;
 public class AddFavouriteCommandTest {
     private static final Set<Index> INDICES_STUB = Set.of(Index.fromOneBased(1),
             Index.fromOneBased(2), Index.fromOneBased(4));
+    private static final String MESSAGE_INVALID_FORMAT = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            AddFavouriteCommand.MESSAGE_USAGE);
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
@@ -52,6 +55,17 @@ public class AddFavouriteCommandTest {
         Set<Index> indices = Set.of(Index.fromOneBased(model.getFilteredPersonList().size() + 1));
         AddFavouriteCommand addFavouriteCommand = new AddFavouriteCommand(indices);
         assertThrows(CommandException.class, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, () ->
+                addFavouriteCommand.execute(model));
+    }
+
+    @Test
+    public void execute_favouriteContact_throwsCommandException() {
+        Set<Index> indices = Set.of(Index.fromOneBased(1));
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(firstPerson).withFavourite(true).build();
+        model.setPerson(firstPerson, editedPerson);
+        AddFavouriteCommand addFavouriteCommand = new AddFavouriteCommand(indices);
+        assertThrows(CommandException.class, MESSAGE_INVALID_FORMAT, () ->
                 addFavouriteCommand.execute(model));
     }
 

--- a/src/test/java/seedu/address/logic/commands/RemoveFavouriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemoveFavouriteCommandTest.java
@@ -1,0 +1,88 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+
+public class RemoveFavouriteCommandTest {
+    private static final Set<Index> INDICES_STUB = Set.of(Index.fromOneBased(1),
+            Index.fromOneBased(2), Index.fromOneBased(4));
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void constructor_nullIndices_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new RemoveFavouriteCommand(null));
+    }
+
+    @Test
+    public void execute_removeFavourite_success() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(firstPerson).withFavourite(true).build();
+        model.setPerson(firstPerson, editedPerson);
+        Set<Index> indices = Set.of(Index.fromOneBased(1));
+        List<String> modifiedContacts = List.of(firstPerson.getName().fullName);
+        RemoveFavouriteCommand removeFavouriteCommand = new RemoveFavouriteCommand(indices);
+        String expectedMessage = String.format(RemoveFavouriteCommand.MESSAGE_SUCCESS, modifiedContacts);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        assertCommandSuccess(removeFavouriteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndex_throwsCommandException() {
+        Set<Index> indices = Set.of(Index.fromOneBased(model.getFilteredPersonList().size() + 1));
+        RemoveFavouriteCommand removeFavouriteCommand = new RemoveFavouriteCommand(indices);
+        assertThrows(CommandException.class, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, () ->
+                removeFavouriteCommand.execute(model));
+    }
+
+    @Test
+    public void equals() {
+        RemoveFavouriteCommand removeFavouriteCommand = new RemoveFavouriteCommand(INDICES_STUB);
+
+        // same object -> returns true
+        assert (removeFavouriteCommand.equals(removeFavouriteCommand));
+
+        // same values -> returns true
+        RemoveFavouriteCommand removeFavouriteCommandCopy = new RemoveFavouriteCommand(INDICES_STUB);
+        assert (removeFavouriteCommand.equals(removeFavouriteCommandCopy));
+
+        // different types -> returns false
+        assert (!removeFavouriteCommand.equals(1));
+
+        // null -> returns false
+        assert (!removeFavouriteCommand.equals(null));
+
+        // different indices -> returns false
+        RemoveFavouriteCommand differentFavouriteCommand = new RemoveFavouriteCommand(Set.of(Index.fromOneBased(1)));
+        assert (!removeFavouriteCommand.equals(differentFavouriteCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        StringBuilder sb = new StringBuilder();
+        INDICES_STUB.forEach(sb::append);
+        RemoveFavouriteCommand removeFavouriteCommand = new RemoveFavouriteCommand(INDICES_STUB);
+        String expected = RemoveFavouriteCommand.class.getCanonicalName() + "{indices=" + sb.toString() + "}";
+        assertEquals(expected, removeFavouriteCommand.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/RemoveFavouriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemoveFavouriteCommandTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -25,6 +26,8 @@ import seedu.address.testutil.PersonBuilder;
 public class RemoveFavouriteCommandTest {
     private static final Set<Index> INDICES_STUB = Set.of(Index.fromOneBased(1),
             Index.fromOneBased(2), Index.fromOneBased(4));
+    private static final String MESSAGE_INVALID_FORMAT = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            RemoveFavouriteCommand.MESSAGE_USAGE);
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
@@ -52,6 +55,14 @@ public class RemoveFavouriteCommandTest {
         Set<Index> indices = Set.of(Index.fromOneBased(model.getFilteredPersonList().size() + 1));
         RemoveFavouriteCommand removeFavouriteCommand = new RemoveFavouriteCommand(indices);
         assertThrows(CommandException.class, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, () ->
+                removeFavouriteCommand.execute(model));
+    }
+
+    @Test
+    public void execute_nonFavouriteContact_throwsCommandException() {
+        Set<Index> indices = Set.of(Index.fromOneBased(2));
+        RemoveFavouriteCommand removeFavouriteCommand = new RemoveFavouriteCommand(indices);
+        assertThrows(CommandException.class, MESSAGE_INVALID_FORMAT, () ->
                 removeFavouriteCommand.execute(model));
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -26,6 +26,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListOrderCommand;
+import seedu.address.logic.commands.RemoveFavouriteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.order.Date;
 import seedu.address.model.order.Order;
@@ -100,6 +101,16 @@ public class AddressBookParserTest {
                 + "i/ 1,2,4"
         );
         assertEquals(new AddFavouriteCommand(indices), command);
+    }
+
+    @Test
+    public void parseCommand_removeFavourite() throws Exception {
+        Set<Index> indices = Set.of(Index.fromOneBased(1), Index.fromOneBased(2), Index.fromOneBased(4));
+        RemoveFavouriteCommand command = (RemoveFavouriteCommand) parser.parseCommand(
+                RemoveFavouriteCommand.COMMAND_WORD + " "
+                        + "i/ 1,2,4"
+        );
+        assertEquals(new RemoveFavouriteCommand(indices), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
@@ -212,5 +213,20 @@ public class ParserUtilTest {
     @Test
     public void parseDate_validValueWithWhitespace_returnsTrimmedDate() throws Exception {
         assertEquals(ParserUtil.parseDate(WHITESPACE + "2020-01-01" + WHITESPACE).toString(), "2020-01-01");
+    }
+
+    @Test
+    public void parseCsv_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseCsv(null));
+    }
+
+    @Test
+    public void parseCsv_validValueWithWhitespace_returnsArray() {
+        assertArrayEquals(ParserUtil.parseCsv("1,2"), new String[]{"1", "2"});
+    }
+
+    @Test
+    public void parseCsv_invalidValueWithRepeatedCommas_returnsArray() {
+        assertArrayEquals(ParserUtil.parseCsv("1,,,,2"), new String[]{"1,,,", "2"});
     }
 }

--- a/src/test/java/seedu/address/logic/parser/RemoveFavouriteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RemoveFavouriteCommandParserTest.java
@@ -1,0 +1,55 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDICES;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.RemoveFavouriteCommand;
+
+public class RemoveFavouriteCommandParserTest {
+    private static final String NON_EMPTY_INDICES = "1,2,4";
+    private static final Set<Index> NON_EMPTY_INDICES_SET = Set.of(Index.fromOneBased(1),
+            Index.fromOneBased(2), Index.fromOneBased(4));
+    private static final String MESSAGE_INVALID_FORMAT = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            RemoveFavouriteCommand.MESSAGE_USAGE);
+    private RemoveFavouriteCommandParser parser = new RemoveFavouriteCommandParser();
+
+    @Test
+    public void parse_indicesSpecified_success() {
+        String userInput = " " + PREFIX_INDICES + " " + NON_EMPTY_INDICES;
+
+        RemoveFavouriteCommand expectedCommand = new RemoveFavouriteCommand(NON_EMPTY_INDICES_SET);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_missingIndices_failure() {
+        String userInput = "";
+        assertParseFailure(parser, userInput, MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidStructure_failure() {
+        // negative indices
+        assertParseFailure(parser, " " + PREFIX_INDICES + "-1", MESSAGE_INVALID_FORMAT);
+
+        // zero index
+        assertParseFailure(parser, " " + PREFIX_INDICES + "0", MESSAGE_INVALID_FORMAT);
+
+        // non-numerical indices
+        assertParseFailure(parser, " " + PREFIX_INDICES + "abcd", MESSAGE_INVALID_FORMAT);
+
+        // invalid prefix
+        assertParseFailure(parser, " " + "d/ abcd", MESSAGE_INVALID_FORMAT);
+
+        // inclusion of preamble
+        assertParseFailure(parser, "1 " + PREFIX_INDICES + "1", MESSAGE_INVALID_FORMAT);
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -28,8 +28,7 @@ public class TypicalPersons {
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253").withCompany("Pauline Veges")
-            .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
-            .withPhone("94351253").withTags("friends").build();
+            .withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432").withCompany("Meiers Pte Ltd")


### PR DESCRIPTION
Implement Remove Favourites functionality
Example use case:
removefav i/ 1,2,4
Expected Successful Output:
Contacts indicated by the indices will be removed as favourites (as reflected by the removal of the Favourite tag from the UI display)

Expected Error Output:
If user does not adhere to the structure provided such as missing the relevant prefix, using other prefixes or indicating non-positive indices then an invalid command prompt is shown:
Invalid command format!  removefav: Removes contacts identified by index number as favourites. Parameters: i/ [INDICES] (must be positive integers separated by commas that correspond to existing favourite contacts) Example: removefav i/ 1,2,5

If user inputs an index that does not correspond to a contact that is currently set as favourite then
Invalid command format!  removefav: Removes contacts identified by index number as favourites. Parameters: i/ [INDICES] (must be positive integers separated by commas that correspond to existing favourite contacts) Example: removefav i/ 1,2,5

If user inputs an index that exceeds the size of the addressbook then 
The person index provided is invalid is displayed

resolves #38 