### PR TITLE
Bug Fix: Commands with No Arguments

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -14,6 +14,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_INVALID_NO_ARGUMENTS_COMMAND = "Give the exact command without trailing text!";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =

--- a/src/main/java/seedu/address/logic/commands/AddFavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddFavouriteCommand.java
@@ -49,7 +49,7 @@ public class AddFavouriteCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
         boolean anyFavourite = this.indices.stream().anyMatch(index ->
-                people.get(index.getZeroBased()).getFavourite());
+                people.get(index.getZeroBased()).getIsFavourite());
         if (anyFavourite) {
             throw new CommandException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -107,7 +107,7 @@ public class EditCommand extends Command {
         Company updatedCompany = editPersonDescriptor.getCompany().orElse(personToEdit.getCompany());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
         ArrayList<Order> updatedOrders = personToEdit.getOrders();
-        boolean updatedIsFavourite = personToEdit.getFavourite();
+        boolean updatedIsFavourite = personToEdit.getIsFavourite();
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedCompany, updatedIsFavourite,
                 updatedTags, updatedOrders);

--- a/src/main/java/seedu/address/logic/commands/RemoveFavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveFavouriteCommand.java
@@ -51,7 +51,7 @@ public class RemoveFavouriteCommand extends Command {
         }
 
         boolean anyNotFavourite = this.indices.stream().anyMatch(index ->
-                !people.get(index.getZeroBased()).getFavourite());
+                !people.get(index.getZeroBased()).getIsFavourite());
         if (anyNotFavourite) {
             throw new CommandException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/commands/ShowFavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowFavouriteCommand.java
@@ -6,7 +6,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_FAVOURITES;
 import seedu.address.model.Model;
 
 /**
- * Lists all persons in the address book to the user.
+ * Lists all favourites in the address book to the user.
  */
 public class ShowFavouriteCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/ShowFavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowFavouriteCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.model.Model.PREDICATE_SHOW_FAVOURITES;
 
 import seedu.address.model.Model;

--- a/src/main/java/seedu/address/logic/commands/ShowFavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowFavouriteCommand.java
@@ -30,6 +30,6 @@ public class ShowFavouriteCommand extends Command {
         }
 
         // instanceof handles nulls
-        return (other instanceof ShowFavouriteCommand);
+        return other instanceof ShowFavouriteCommand ? true : false;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ShowFavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowFavouriteCommand.java
@@ -21,4 +21,15 @@ public class ShowFavouriteCommand extends Command {
         model.updateFilteredPersonList(PREDICATE_SHOW_FAVOURITES);
         return new CommandResult(MESSAGE_SUCCESS);
     }
+
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        return (other instanceof ShowFavouriteCommand);
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/ShowFavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowFavouriteCommand.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.Model.PREDICATE_SHOW_FAVOURITES;
+
+import seedu.address.model.Model;
+
+/**
+ * Lists all persons in the address book to the user.
+ */
+public class ShowFavouriteCommand extends Command {
+
+    public static final String COMMAND_WORD = "showfav";
+
+    public static final String MESSAGE_SUCCESS = "Displayed all favourites";
+
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(PREDICATE_SHOW_FAVOURITES);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ShowFavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowFavouriteCommand.java
@@ -30,6 +30,6 @@ public class ShowFavouriteCommand extends Command {
         }
 
         // instanceof handles nulls
-        return other instanceof ShowFavouriteCommand ? true : false;
+        return other instanceof ShowFavouriteCommand;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -20,8 +20,8 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListOrderCommand;
-import seedu.address.logic.commands.ShowFavouriteCommand;
 import seedu.address.logic.commands.RemoveFavouriteCommand;
+import seedu.address.logic.commands.ShowFavouriteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -67,7 +67,7 @@ public class AddressBookParser {
             return new DeleteCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
+            return new ClearCommandParser().parse(arguments);
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
@@ -82,16 +82,16 @@ public class AddressBookParser {
             return new ListOrderCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            return new ListCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
-            return new ExitCommand();
+            return new ExitCommandParser().parse(arguments);
 
         case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
+            return new HelpCommandParser().parse(arguments);
 
         case ShowFavouriteCommand.COMMAND_WORD:
-            return new ShowFavouriteCommand();
+            return new ShowFavouriteCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -20,6 +20,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListOrderCommand;
+import seedu.address.logic.commands.ShowFavouriteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -88,6 +89,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ShowFavouriteCommand.COMMAND_WORD:
+            return new ShowFavouriteCommand();
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_NO_ARGUMENTS_COMMAND;
+
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ClearCommand object
+ */
+public class ClearCommandParser implements Parser<ClearCommand> {
+
+    /**
+     * Parses any potential {@code String} of text in the context of the HelpCommand that should not be there,
+     * and returns an AddCommand object for execution.
+     * @throws ParseException if the user input has any text after the command word
+     */
+    public ClearCommand parse(String args) throws ParseException {
+        if (args.isEmpty() || args.isBlank()) {
+            return new ClearCommand();
+        }
+        throw new ParseException(MESSAGE_INVALID_NO_ARGUMENTS_COMMAND);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_NO_ARGUMENTS_COMMAND;
+import static seedu.address.logic.parser.ParserUtil.parseNoArgs;
 
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -16,10 +16,8 @@ public class ClearCommandParser implements Parser<ClearCommand> {
      * @throws ParseException if the user input has any text after the command word
      */
     public ClearCommand parse(String args) throws ParseException {
-        if (args.isEmpty() || args.isBlank()) {
-            return new ClearCommand();
-        }
-        throw new ParseException(MESSAGE_INVALID_NO_ARGUMENTS_COMMAND);
+        parseNoArgs(args);
+        return new ClearCommand();
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ExitCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExitCommandParser.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_NO_ARGUMENTS_COMMAND;
+import static seedu.address.logic.parser.ParserUtil.parseNoArgs;
 
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -16,10 +16,8 @@ public class ExitCommandParser implements Parser<ExitCommand> {
      * @throws ParseException if the user input has any text after the command word
      */
     public ExitCommand parse(String args) throws ParseException {
-        if (args.isEmpty() || args.isBlank()) {
-            return new ExitCommand();
-        }
-        throw new ParseException(MESSAGE_INVALID_NO_ARGUMENTS_COMMAND);
+        parseNoArgs(args);
+        return new ExitCommand();
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ExitCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExitCommandParser.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_NO_ARGUMENTS_COMMAND;
+
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ExitCommand object
+ */
+public class ExitCommandParser implements Parser<ExitCommand> {
+
+    /**
+     * Parses any potential {@code String} of text in the context of the ExitCommand that should not be there,
+     * and returns an AddCommand object for execution.
+     * @throws ParseException if the user input has any text after the command word
+     */
+    public ExitCommand parse(String args) throws ParseException {
+        if (args.isEmpty() || args.isBlank()) {
+            return new ExitCommand();
+        }
+        throw new ParseException(MESSAGE_INVALID_NO_ARGUMENTS_COMMAND);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_NO_ARGUMENTS_COMMAND;
+import static seedu.address.logic.parser.ParserUtil.parseNoArgs;
 
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -16,10 +16,8 @@ public class HelpCommandParser implements Parser<HelpCommand> {
      * @throws ParseException if the user input has any text after the command word
      */
     public HelpCommand parse(String args) throws ParseException {
-        if (args.isEmpty() || args.isBlank()) {
-            return new HelpCommand();
-        }
-        throw new ParseException(MESSAGE_INVALID_NO_ARGUMENTS_COMMAND);
+        parseNoArgs(args);
+        return new HelpCommand();
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/HelpCommandParser.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_NO_ARGUMENTS_COMMAND;
+
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new HelpCommand object
+ */
+public class HelpCommandParser implements Parser<HelpCommand> {
+
+    /**
+     * Parses any potential {@code String} of text in the context of the HelpCommand that should not be there,
+     * and returns an AddCommand object for execution.
+     * @throws ParseException if the user input has any text after the command word
+     */
+    public HelpCommand parse(String args) throws ParseException {
+        if (args.isEmpty() || args.isBlank()) {
+            return new HelpCommand();
+        }
+        throw new ParseException(MESSAGE_INVALID_NO_ARGUMENTS_COMMAND);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_NO_ARGUMENTS_COMMAND;
+
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ListCommand object
+ */
+public class ListCommandParser implements Parser<ListCommand> {
+
+    /**
+     * Parses any potential {@code String} of text in the context of the ListCommand that should not be there,
+     * and returns an AddCommand object for execution.
+     * @throws ParseException if the user input has any text after the command word
+     */
+    public ListCommand parse(String args) throws ParseException {
+        if (args.isEmpty() || args.isBlank()) {
+            return new ListCommand();
+        }
+        throw new ParseException(MESSAGE_INVALID_NO_ARGUMENTS_COMMAND);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_NO_ARGUMENTS_COMMAND;
+import static seedu.address.logic.parser.ParserUtil.parseNoArgs;
 
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -16,10 +16,8 @@ public class ListCommandParser implements Parser<ListCommand> {
      * @throws ParseException if the user input has any text after the command word
      */
     public ListCommand parse(String args) throws ParseException {
-        if (args.isEmpty() || args.isBlank()) {
-            return new ListCommand();
-        }
-        throw new ParseException(MESSAGE_INVALID_NO_ARGUMENTS_COMMAND);
+        parseNoArgs(args);
+        return new ListCommand();
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -164,6 +164,7 @@ public class ParserUtil {
             return;
         }
         throw new ParseException(MESSAGE_INVALID_NO_ARGUMENTS_COMMAND);
+    }
 
     /**
      * Parses {@code String csv} into a {@code String[]}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_NO_ARGUMENTS_COMMAND;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -151,5 +152,16 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+    /**
+     * Parses a {@code String args} and checks that it is empty or blank.
+     *
+     * @throws ParseException if the given {@code args} contains non-space text.
+     */
+    public static void parseNoArgs(String args) throws ParseException {
+        if (args.isEmpty() || args.isBlank()) {
+            return;
+        }
+        throw new ParseException(MESSAGE_INVALID_NO_ARGUMENTS_COMMAND);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ShowFavouriteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ShowFavouriteCommandParser.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_NO_ARGUMENTS_COMMAND;
+import static seedu.address.logic.parser.ParserUtil.parseNoArgs;
 
 import seedu.address.logic.commands.ShowFavouriteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -16,10 +16,8 @@ public class ShowFavouriteCommandParser implements Parser<ShowFavouriteCommand> 
      * @throws ParseException if the user input has any text after the command word
      */
     public ShowFavouriteCommand parse(String args) throws ParseException {
-        if (args.isEmpty() || args.isBlank()) {
-            return new ShowFavouriteCommand();
-        }
-        throw new ParseException(MESSAGE_INVALID_NO_ARGUMENTS_COMMAND);
+        parseNoArgs(args);
+        return new ShowFavouriteCommand();
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ShowFavouriteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ShowFavouriteCommandParser.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_NO_ARGUMENTS_COMMAND;
+
+import seedu.address.logic.commands.ShowFavouriteCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ShowFavouriteCommand object
+ */
+public class ShowFavouriteCommandParser implements Parser<ShowFavouriteCommand> {
+
+    /**
+     * Parses any potential {@code String} of text in the context of the ShowFavouriteCommand that should not be there,
+     * and returns an AddCommand object for execution.
+     * @throws ParseException if the user input has any text after the command word
+     */
+    public ShowFavouriteCommand parse(String args) throws ParseException {
+        if (args.isEmpty() || args.isBlank()) {
+            return new ShowFavouriteCommand();
+        }
+        throw new ParseException(MESSAGE_INVALID_NO_ARGUMENTS_COMMAND);
+    }
+
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -14,6 +14,9 @@ public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
 
+    /** {@code Predicate} that evaluates to whether a person is a favourite contact */
+    Predicate<Person> PREDICATE_SHOW_FAVOURITES = unused -> unused.getIsFavourite();
+
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
      */

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -106,9 +106,10 @@ public class Person {
         this.isFavourite = true;
     }
 
-    public boolean getFavourite() {
+    public boolean getIsFavourite() {
         return this.isFavourite;
     }
+
     public ArrayList<Order> getOrders() {
         return orders;
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -65,7 +65,7 @@ class JsonAdaptedPerson {
         email = source.getEmail().value;
         address = source.getAddress().value;
         company = source.getCompany().companyName;
-        isFavourite = source.getFavourite();
+        isFavourite = source.getIsFavourite();
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -15,7 +15,7 @@ import seedu.address.commons.core.LogsCenter;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
+    public static final String USERGUIDE_URL = "https://ay2324s2-cs2103t-t16-3.github.io/tp/";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -60,7 +60,7 @@ public class PersonCard extends UiPart<Region> {
         email.setText(person.getEmail().value);
         company.setText(person.getCompany().companyName);
         orders.setText(person.getOrders().size() + " orders");
-        if (person.getFavourite()) {
+        if (person.getIsFavourite()) {
             favourite.setText("Favourite");
         } else {
             // Collapse empty label

--- a/src/test/java/seedu/address/logic/commands/ShowFavouriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ShowFavouriteCommandTest.java
@@ -14,7 +14,7 @@ import seedu.address.model.UserPrefs;
 import seedu.address.testutil.PersonBuilder;
 
 /**
- * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
+ * Contains integration tests (interaction with the Model) and unit tests for ShowFavouriteCommand.
  */
 public class ShowFavouriteCommandTest {
 

--- a/src/test/java/seedu/address/logic/commands/ShowFavouriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ShowFavouriteCommandTest.java
@@ -1,0 +1,66 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.testutil.PersonBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
+ */
+public class ShowFavouriteCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_showFavouriteNoFavourites_success() {
+        ShowFavouriteCommand showFavouriteCommand = new ShowFavouriteCommand();
+
+        String expectedMessage = ShowFavouriteCommand.MESSAGE_SUCCESS;
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        expectedModel.updateFilteredPersonList(person -> false); // no favourites in typical address book
+        model.updateFilteredPersonList(Model.PREDICATE_SHOW_FAVOURITES);
+        assertCommandSuccess(showFavouriteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_showFavouriteWithFavourites_success() {
+        ShowFavouriteCommand showFavouriteCommand = new ShowFavouriteCommand();
+
+        String expectedMessage = ShowFavouriteCommand.MESSAGE_SUCCESS;
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        model.setPerson(ALICE, new PersonBuilder(ALICE).withFavourite(true).build());
+
+        expectedModel.updateFilteredPersonList(person -> person.isSamePerson(ALICE)); // only Alice is favourited
+        model.updateFilteredPersonList(Model.PREDICATE_SHOW_FAVOURITES);
+        assertCommandSuccess(showFavouriteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void equals() {
+        ShowFavouriteCommand showFavouriteCommand = new ShowFavouriteCommand();
+
+        // same object -> returns true
+        assert (showFavouriteCommand.equals(showFavouriteCommand));
+
+        // same values -> returns true
+        ShowFavouriteCommand showFavouriteCommandCopy = new ShowFavouriteCommand();
+        assert (showFavouriteCommand.equals(showFavouriteCommandCopy));
+
+        // different types -> returns false
+        assertFalse(showFavouriteCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(showFavouriteCommand.equals(null));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ShowFavouriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ShowFavouriteCommandTest.java
@@ -5,16 +5,12 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import javafx.collections.transformation.FilteredList;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.UniquePersonList;
 import seedu.address.testutil.PersonBuilder;
 
 /**

--- a/src/test/java/seedu/address/logic/commands/ShowFavouriteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ShowFavouriteCommandTest.java
@@ -5,12 +5,16 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import javafx.collections.transformation.FilteredList;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.UniquePersonList;
 import seedu.address.testutil.PersonBuilder;
 
 /**
@@ -18,22 +22,9 @@ import seedu.address.testutil.PersonBuilder;
  */
 public class ShowFavouriteCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-
-    @Test
-    public void execute_showFavouriteNoFavourites_success() {
-        ShowFavouriteCommand showFavouriteCommand = new ShowFavouriteCommand();
-
-        String expectedMessage = ShowFavouriteCommand.MESSAGE_SUCCESS;
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-
-        expectedModel.updateFilteredPersonList(person -> false); // no favourites in typical address book
-        model.updateFilteredPersonList(Model.PREDICATE_SHOW_FAVOURITES);
-        assertCommandSuccess(showFavouriteCommand, model, expectedMessage, expectedModel);
-    }
-
     @Test
     public void execute_showFavouriteWithFavourites_success() {
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         ShowFavouriteCommand showFavouriteCommand = new ShowFavouriteCommand();
 
         String expectedMessage = ShowFavouriteCommand.MESSAGE_SUCCESS;

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -124,7 +124,7 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_showFav() throws Exception {
+    public void parseCommand_showFavourite() throws Exception {
         assertTrue(parser.parseCommand(ShowFavouriteCommand.COMMAND_WORD) instanceof ShowFavouriteCommand);
         assertTrue(parser.parseCommand(ShowFavouriteCommand.COMMAND_WORD + " 3") instanceof ShowFavouriteCommand);
     }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -26,6 +26,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListOrderCommand;
+import seedu.address.logic.commands.ShowFavouriteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.order.Date;
 import seedu.address.model.order.Order;
@@ -120,6 +121,12 @@ public class AddressBookParserTest {
         ListOrderCommand command = (ListOrderCommand) parser.parseCommand(ListOrderCommand.COMMAND_WORD
                 + " " + targetIndex.getOneBased());
         assertEquals(new ListOrderCommand(targetIndex), command);
+    }
+
+    @Test
+    public void parseCommand_showFav() throws Exception {
+        assertTrue(parser.parseCommand(ShowFavouriteCommand.COMMAND_WORD) instanceof ShowFavouriteCommand);
+        assertTrue(parser.parseCommand(ShowFavouriteCommand.COMMAND_WORD + " 3") instanceof ShowFavouriteCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_NO_ARGUMENTS_COMMAND;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -50,7 +51,9 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_clear() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " ") instanceof ClearCommand);
+        assertThrows(ParseException.class, MESSAGE_INVALID_NO_ARGUMENTS_COMMAND, () -> parser.parseCommand(
+                ClearCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
@@ -80,7 +83,9 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_exit() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " ") instanceof ExitCommand);
+        assertThrows(ParseException.class, MESSAGE_INVALID_NO_ARGUMENTS_COMMAND, () -> parser.parseCommand(
+                ExitCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
@@ -106,13 +111,17 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_help() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " ") instanceof HelpCommand);
+        assertThrows(ParseException.class, MESSAGE_INVALID_NO_ARGUMENTS_COMMAND, () -> parser.parseCommand(
+                ListCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " ") instanceof ListCommand);
+        assertThrows(ParseException.class, MESSAGE_INVALID_NO_ARGUMENTS_COMMAND, () -> parser.parseCommand(
+                ListCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
@@ -126,7 +135,9 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_showFavourite() throws Exception {
         assertTrue(parser.parseCommand(ShowFavouriteCommand.COMMAND_WORD) instanceof ShowFavouriteCommand);
-        assertTrue(parser.parseCommand(ShowFavouriteCommand.COMMAND_WORD + " 3") instanceof ShowFavouriteCommand);
+        assertTrue(parser.parseCommand(ShowFavouriteCommand.COMMAND_WORD + " ") instanceof ShowFavouriteCommand);
+        assertThrows(ParseException.class, MESSAGE_INVALID_NO_ARGUMENTS_COMMAND, () -> parser.parseCommand(
+                ShowFavouriteCommand.COMMAND_WORD + " 3"));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -95,7 +95,7 @@ public class PersonTest {
     public void toStringMethod() {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", company=" + ALICE.getCompany()
-                + ", isFavourite=" + ALICE.getFavourite() + ", tags=" + ALICE.getTags()
+                + ", isFavourite=" + ALICE.getIsFavourite() + ", tags=" + ALICE.getTags()
                 + ", orders=" + ALICE.getOrders() + "}";
         assertEquals(expected, ALICE.toString());
     }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -58,7 +58,7 @@ public class PersonBuilder {
         email = personToCopy.getEmail();
         address = personToCopy.getAddress();
         company = personToCopy.getCompany();
-        isFavourite = personToCopy.getFavourite();
+        isFavourite = personToCopy.getIsFavourite();
         tags = new HashSet<>(personToCopy.getTags());
         orders = new ArrayList<>(personToCopy.getOrders());
     }


### PR DESCRIPTION
Commands with no further arguments should be unsuccessful if user inputs further non-space characters, to avoid confusion. For this purpose, simple new Parsers are introduced.
This PR also includes all changes from #45.

Affected commands:
- List
- Clear
- Exit
- ShowFav
- Help

<img width="453" alt="Screenshot 2024-03-26 at 2 19 49 AM" src="https://github.com/AY2324S2-CS2103T-T16-3/tp/assets/60679866/0c75195e-a655-45a8-8220-839c6c2e9c51">

(Following what Guan Quan suggested in postmortem of v1.2, I have only requested Gavin to review this since I have discussed this issue with him and he is most familiar with my intentions)