### PR TITLE
Enable assertions in gradle file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,4 +69,8 @@ shadowJar {
     archiveFileName = 'addressbook.jar'
 }
 
+run {
+    enableAssertions = true
+}
+
 defaultTasks 'clean', 'test'


### PR DESCRIPTION
Enable assertions in build.gradle, as part of TP requirement