### PR TITLE
Change remark validation

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddOrderCommand.java
@@ -14,7 +14,7 @@ import seedu.address.model.order.Order;
 import seedu.address.model.person.Person;
 
 /**
- * Lists all persons in the address book to the user.
+ * Adds an order to a person identified by the index from the address book.
  */
 public class AddOrderCommand extends Command {
     public static final String COMMAND_WORD = "addorder";

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -117,7 +117,7 @@ public class ParserUtil {
      * Parses a {@code String date} into an {@code Date}.
      * Leading and trailing whitespaces will be trimmed.
      *
-     * @throws ParseException if the given {@code date} is invalid.
+     * @throws ParseException if the given {@code Date} is invalid.
      */
     public static Date parseDate(String date) throws ParseException {
         requireNonNull(date);
@@ -131,7 +131,7 @@ public class ParserUtil {
     /**
      * Parses a {@code String remark} into a {@code Remark}.
      *
-     * @throws ParseException if the given {@code remark} is invalid.
+     * @throws ParseException if the given {@code Remark} is invalid.
      */
     public static Remark parseRemark(String remark) throws ParseException {
         requireNonNull(remark);

--- a/src/main/java/seedu/address/model/order/Remark.java
+++ b/src/main/java/seedu/address/model/order/Remark.java
@@ -9,15 +9,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Remark {
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Remark should only contain alphanumeric characters, spaces, hyphens and/or apostrophes, "
-                    + "and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Remark can take any values, and it should not be blank";
 
     /*
      * The first character of the remark must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}'\\-][\\p{Alnum}'\\- ]*";
+    public static final String VALIDATION_REGEX = "[^\\s].*";
 
     public final String remark;
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedOrder.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedOrder.java
@@ -19,7 +19,7 @@ class JsonAdaptedOrder {
     private final String remark;
 
     /**
-     * Constructs a {@code JsonAdaptedOrder} with the given {@code order}.
+     * Constructs a {@code JsonAdaptedOrder} with the given {@code Order}.
      */
     @JsonCreator
     public JsonAdaptedOrder(@JsonProperty("arrivalDate") String arrivalDate,

--- a/src/test/java/seedu/address/model/order/RemarkTest.java
+++ b/src/test/java/seedu/address/model/order/RemarkTest.java
@@ -27,8 +27,6 @@ public class RemarkTest {
         // invalid remark
         assertFalse(Remark.isValidRemark("")); // empty string
         assertFalse(Remark.isValidRemark(" ")); // spaces only
-        assertFalse(Remark.isValidRemark("^")); // only non-alphanumeric characters
-        assertFalse(Remark.isValidRemark("chick*n wings")); // contains non-alphanumeric characters
 
         // valid remark
         assertTrue(Remark.isValidRemark("chicken wings")); // alphabetical characters only

--- a/src/test/java/seedu/address/storage/JsonAdaptedOrderTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedOrderTest.java
@@ -14,7 +14,7 @@ public class JsonAdaptedOrderTest {
     private static final String VALID_DATE = "2020-01-01";
     private static final String VALID_REMARK = "100 chicken wings";
     private static final String INVALID_DATE = "2020-13-01";
-    private static final String INVALID_REMARK = "****";
+    private static final String INVALID_REMARK = "";
 
     private static final Order ORDER = new Order(new Date(VALID_DATE), new Remark(VALID_REMARK));
 


### PR DESCRIPTION
- Remarks field accepts more inputs now. Remarks should not be too restricted, as after all, that is what a remark is about. 
- Chose to deliberately allow `/` in remark field, which is similar to the implementation of address
- Fix minor formatting issues for addorder docs as well